### PR TITLE
Update bluebird to 3.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
   },
   "homepage": "https://github.com/db-migrate/db-migrate-base",
   "dependencies": {
-    "bluebird": "^2.9.34"
+    "bluebird": "^3.1.1"
   }
 }


### PR DESCRIPTION
They changed the default promisification to pass on only the first argument of the callback and ignore the others. If needed, bluebird can be told to return an array with all arguments instead.
I think bumping bluebird and using the new default behaviour should be fine for this project.
