### PR TITLE
Support documented mysql promise based insert command.

### DIFF
--- a/index.js
+++ b/index.js
@@ -344,7 +344,6 @@ var Base = Class.extend({
 
       columnNameArray = valueArray;
       valueArray = callback;
-      callback = arguments[3] ? arguments[3] : throw;
     }
     else {
 
@@ -363,7 +362,12 @@ var Base = Class.extend({
     }
 
     if (columnNameArray.length !== valueArray.length) {
-      return callback(new Error('The number of columns does not match the number of values.'));
+      var error = new Error('The number of columns does not match the number of values.');
+      if (typeof callback === 'function') {
+        return callback(error);
+      } else {
+        throw error;
+      }
     }
 
     var sql = util.format('INSERT INTO %s ', this.escapeDDL(tableName));

--- a/index.js
+++ b/index.js
@@ -340,11 +340,11 @@ var Base = Class.extend({
 
     var columnNameArray = {};
 
-    if( arguments.length > 3 ) {
+    if( arguments.length > 3 || Array.isArray(callback)) {
 
       columnNameArray = valueArray;
       valueArray = callback;
-      callback = arguments[3];
+      callback = arguments[3] ? arguments[3] : throw;
     }
     else {
 


### PR DESCRIPTION
This updates the default DB insert command to match the documentation. Previously it seems that it was not updated to support promises like other DB commands were.

[Mysql insert documentation](https://db-migrate.readthedocs.io/en/latest/API/SQL/#inserttablename-columnnamearray-valuearray-callback)

It doesn't note that the callback is optional, but in the [Creating Migrations](https://db-migrate.readthedocs.io/en/latest/Getting%20Started/usage/#creating-migrations) documentation it states that db-migrate upgraded to a promise-based API, and in [other methods](https://db-migrate.readthedocs.io/en/latest/API/programable/#createdatabasedbname-callback) it states that the callback function is omitted if you wish to use the promise API. So that is how I expect all of the methods to work.

I'm making as few changes to the code as possible because this function is passed through directly by the mysql driver, called with 3 args in the [nosql driver](https://github.com/db-migrate/mongodb/blob/master/index.js#L189), and maybe more, so I'm trying to keep it backwards compatible.

**tl:dr;** Lots of justification for a really small change.

Note that the undocumented `update` method has a similar problem which I haven't fixed.