### PR TITLE
Insert generates invalid SQL when multiple rows and values passed

### DIFF
--- a/index.js
+++ b/index.js
@@ -487,6 +487,8 @@ var Base = Class.extend({
           } else {
             values_part[i] += valueArray[i][index];
           }
+          
+          values_part[i] += ',';
         }
       } else {
         if (typeof valueArray[index] === 'string') {


### PR DESCRIPTION
`insert` generates invalid SQL statement when used to fill multiple columns:
```
db.insert('table',
  [ 'column1', 'column2' ],
  [ [ 'data11', 'data21' ], [ 'data12', 'data22' ] ]
);
```
delimiters are not added properly so in the final statement parts of the real data get sliced, ending up in statements like this:
```
INSERT INTO "table" ("column1","column2") VALUES ('data11''data21),('data12''data22);
```