### PR TITLE
Insert improperly compares number of columns and value columns

### DIFF
--- a/index.js
+++ b/index.js
@@ -447,10 +447,12 @@ var Base = Class.extend({
 
   insert: function(tableName, valueArray, callback) {
     var columnNameArray = {};
+    var numValueColumns;
 
     if (arguments.length > 3 || Array.isArray(callback)) {
       columnNameArray = valueArray;
       valueArray = callback;
+      numValueColumns = Array.isArray(valueArray[0]) ? valueArray[0].length : valueArray.length;
     } else {
       var names;
       if (Array.isArray(valueArray)) {
@@ -462,9 +464,11 @@ var Base = Class.extend({
       for (var i = 0; i < names.length; ++i) {
         columnNameArray[names[i]] = names[i];
       }
+      
+      numValueColumns = valueArray.length;
     }
 
-    if (columnNameArray.length !== valueArray.length) {
+    if (columnNameArray.length !== numValueColumns) {
       return Promise.reject(
         new Error('The number of columns does not match the number of values.')
       ).nodeify(callback);


### PR DESCRIPTION
Insert performs an improper check when multiple columns and multiple rows of data passed to the call.

Example:

```
insert('table_name',
  [ 'column1', 'column2' ],
  [ [ 'row1_col1', 'row1_col2' ], [ 'row2_col1', 'row2_col2' ], [ 'row3_col1', 'row3_col2' ] ]
);
```
The above should be ok as the number of columns matches the number of value-columns, but it does throw an error in the current implementation.